### PR TITLE
github ci pack containers

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,4 +29,4 @@ jobs:
         shell: bash
         run: make release TOKEN=${GITHUB_TOKEN}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}

--- a/.github/workflows/release_container_tars.yaml
+++ b/.github/workflows/release_container_tars.yaml
@@ -1,0 +1,24 @@
+name: release_to_copr
+
+on:
+  push:
+    tags:
+      - '**.microshift-20**' # matching : 4.7.0-0.microshift-2021-07-07-002815 - 4.8.0-0.microshift-2022-01-06-210147
+
+jobs:  
+  trigger_copr_repo_build:
+    runs-on: ubuntu-latest
+    container:
+      image: registry.fedoraproject.org/fedora:35
+    steps:
+      - shell: bash # git must be present before checkout
+        run: sudo dnf install -y copr-cli golang gcc make systemd policycoreutils rpm-build git which podman
+
+      - name: Checkout source
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: tars
+        shell: bash
+        run: ./packaging/images/components/archive.sh

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -1,4 +1,5 @@
-on: [push, pull_request]
+on: push
+#on: [push, pull_request]
 name: Unit Testing
 jobs:
   test:

--- a/.github/workflows/ubuntu.yaml
+++ b/.github/workflows/ubuntu.yaml
@@ -3,8 +3,8 @@ on:
   push:
     branches: ["main", "release*"]
     tags: ["*"]
-  pull_request:
-    branches: ["main", "release*"]
+#  pull_request:
+#    branches: ["main", "release*"]
 
 env:
   GO_VERSION: "1.16"

--- a/packaging/images/components/archive.sh
+++ b/packaging/images/components/archive.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+get="${SCRIPT_DIR}/../../../pkg/release/get.sh"
+
+ARCHITECTURES=${ARCHITECTURES:-"arm64 amd64"}
+BASE_VERSION=${BASE_VERSION:-$("${get}" base)}
+OUTPUT_DIR=${OUTPUT_DIR:-$(pwd)/archive}
+
+TMP_DIR=$(mktemp -d)
+
+mkdir -p "${OUTPUT_DIR}"
+chown a+rw "${OUTPUT_DIR}"
+
+for arch in $ARCHITECTURES; do
+    images=$("${get}" images $arch)
+    storage="${TMP_DIR}/${arch}/containers"
+    mkdir -p "${storage}"
+    echo "Pulling images for architecture ${arch} ==================="
+    for image in $images; do
+        echo pulling $image @$arch
+        # some imported images are armhfp instead of arm
+        podman pull --arch $arch --root "${storage}" "${image}" || echo "FALLBACK! ${arch}" && \
+          [ "${arch}" == "arm" ] && podman pull --arch armhfp --root "${TMP_DIR}/${arch}" "${image}"
+    done
+
+    echo ""
+    echo "Packing tarball for architecture ${arch} =================="
+    pushd ${storage}
+    tar cfj "${OUTPUT_DIR}/microshift-containers-${BASE_VERSION}-${arch}.tar.bz2" .
+    chown a+rw "${OUTPUT_DIR}/microshift-containers-${BASE_VERSION}-${arch}.tar.bz2"
+    popd
+    rm -rf ${storage}
+done
+
+
+
+

--- a/packaging/images/microshift/Dockerfile
+++ b/packaging/images/microshift/Dockerfile
@@ -29,7 +29,12 @@ RUN microdnf install -y \
     && microdnf clean all
 COPY --from=builder /opt/app-root/src/github.com/redhat-et/microshift/_output/bin/linux_$ARCH/microshift /usr/bin/microshift
 
-ENTRYPOINT ["/usr/bin/microshift"]
+RUN mkdir -p /root/crio.conf.d
+
+COPY packaging/crio.conf.d/microshift.conf /root/crio.conf.d/microshift.conf
+COPY packaging/images/microshift/entrypoint.sh /root/entrypoint.sh
+
+ENTRYPOINT ["/root/entrypoint.sh"]
 CMD ["run"]
 
 # To start:

--- a/packaging/images/microshift/entrypoint.sh
+++ b/packaging/images/microshift/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+mkdir -p /etc/crio/crio.conf.d
+cp /root/crio.conf.d/microshift.conf /etc/crio/crio.conf.d/microshift.conf
+
+# switch to microshift process
+exec /usr/bin/microshift run

--- a/packaging/rpm/make-microshift-app-images-rpm.sh
+++ b/packaging/rpm/make-microshift-app-images-rpm.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+# First arg: file path containing user images per line
+# Second arg: container storage dir path
+# Third arg:  RPMBUILD_DIR
+
+RPMBUILD_DIR=$3
+_img_dir_=$2
+
+declare -a ARRAY
+
+#link filedescriptor 10 with stdin (standard input)
+exec 10<&0
+
+#stdin replaced with a file supplied as a first argument
+exec < $1
+let count=0
+
+#read user images into ARRAY
+while read LINE; do
+   ARRAY[$count]=$LINE
+   ((count++))
+done
+
+#restore stdin from file descriptor 10 then close filedescriptor 10
+exec 0<&10 10<&-
+
+#Generate microshift-app-images.spec 
+touch ./microshift-app-images.spec
+cat >./microshift-app-images.spec <<EOF
+%global _img_dir $_img_dir_
+%global imageStore %{buildroot}%{_img_dir}
+%global _IMAGES_ ${ARRAY[@]}
+
+Name: microshift-app-images
+Version: 1
+Release: 1
+Summary: Creates RO container storage for user applications
+License: Apache License 2.0
+URL: https://github.com/redhat-et/microshift
+
+BuildRequires:  podman
+BuildRequires: crio
+
+
+%description
+This rpm creates a RO container storage for user applications, pull the app images and add the path to additional container image stores on target machine.
+
+%prep
+
+if [ -d  %{imageStore} ] 
+then
+   sudo rm -rf  %{imageStore}
+fi
+
+%build
+
+%install
+
+mkdir -p %{imageStore}
+
+declare -a ListOfImages=(%{_IMAGES_})
+
+
+for val in \${ListOfImages[@]}; do
+   sudo podman pull --root %{imageStore} \$val
+done
+sudo chmod -R a+rx  %{imageStore}
+
+
+%post
+sudo sed -i '/^additionalimagestores =*/a "$_img_dir_",' /etc/containers/storage.conf
+# if crio was already started, restart it so it read from new imagestore
+systemctl is-active --quiet crio && systemctl restart --quiet crio
+
+
+%files
+%{_img_dir}/*
+
+EOF
+cp ./microshift-app-images.spec $RPMBUILD_DIR/SPECS/microshift-app-images.spec
+
+rpmbuild -bb --define "_topdir ${RPMBUILD_DIR}" $RPMBUILD_DIR/SPECS/microshift-app-images.spec

--- a/packaging/rpm/make-microshift-images-rpm.sh
+++ b/packaging/rpm/make-microshift-images-rpm.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -e -o pipefail
+
+# generated from other info
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+BASE_VERSION="$(${SCRIPT_DIR}/../../pkg/release/get.sh base)"
+TARBALL_FILE="microshift-pkg-release-${BASE_VERSION}.tar.gz"
+RPMBUILD_DIR="${SCRIPT_DIR}/_rpmbuild/"
+BUILD=${BUILD:-$2}
+BUILD=${BUILD:-all}
+TARGET=${TARGET:-$3}
+TARGET=${TARGET:-x86_64}
+
+
+case $BUILD in
+  all) RPMBUILD_OPT=-ba ;;
+  rpm) RPMBUILD_OPT=-bb ;;
+  srpm) RPMBUILD_OPT=-bs ;;
+esac
+
+ARCHITECTURES=${ARCHITECTURES:-"x86_64 arm64 arm ppc64le riscv64"}
+
+build() {
+  cat >"${RPMBUILD_DIR}"SPECS/microshift-images.spec <<EOF
+%global baseVersion ${BASE_VERSION}
+
+EOF
+  for arch in $ARCHITECTURES; do
+    echo "%define images_${arch} \"$(${SCRIPT_DIR}/../../pkg/release/get.sh images $arch |  tr '\n' ' ')\"" >> "${RPMBUILD_DIR}"SPECS/microshift-images.spec
+    echo "" >> "${RPMBUILD_DIR}"SPECS/microshift-images.spec
+  done
+
+  cat "${SCRIPT_DIR}/microshift-images.spec" >> "${RPMBUILD_DIR}SPECS/microshift-images.spec"
+
+  sudo rpmbuild "${RPMBUILD_OPT}" --target $TARGET --define "_topdir ${RPMBUILD_DIR}" "${RPMBUILD_DIR}SPECS/microshift-images.spec"
+}
+
+# prepare the rpmbuild env
+mkdir -p "${RPMBUILD_DIR}"/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+
+case $1 in
+    local)
+           build
+           ;;
+    *)
+      echo "Usage: $0 local [all|rpm|srpm]"
+      exit 1
+esac

--- a/packaging/rpm/microshift-images.spec
+++ b/packaging/rpm/microshift-images.spec
@@ -1,0 +1,116 @@
+Name: microshift-images
+
+# disable dynamic rpmbuild checks
+%global __os_install_post /bin/true
+%global __arch_install_post /bin/true
+AutoReqProv: no
+
+# where do we want the images to be stored on the final system
+%global imageStore /opt/microshift/images
+%global imageStoreSed %(echo %{imageStore} | sed 's/\//\\\//g')
+
+%define version %(echo %{baseVersion} | sed s/-/_/g)
+
+# to-be-improved:
+# avoid warnings for container layers:
+#   - warning: absolute symlink:
+#   - warning: Duplicate build-ids
+
+Version: %{version}
+Release: 2
+
+Summary: MicroShift related container images
+License: Apache License 2.0
+URL: https://github.com/redhat-et/microshift
+
+BuildRequires: podman
+Requires: crio
+
+
+%description
+This rpm creates a custom RO container storage for the MicroShift container images
+and pull images and add path to additional container image stores.
+
+%prep
+
+
+if [ -d  %{buildroot}%{imageStore} ]
+then
+   sudo rm -rf  %{buildroot}%{imageStore}
+fi
+
+%build
+
+
+%install
+
+mkdir -p %{buildroot}%{imageStore}
+
+%define arch %{_arch}
+
+# aarch64 is arm64 for container regisitries
+
+%ifarch %{arm} aarch64
+%define arch arm64
+%endif
+
+pull_arch="--arch %{arch}"
+
+# for x86_64 we don't want to specify the arch otherwise quay gets grumpy
+
+%ifarch x86_64
+pull_arch=""
+images=%{images_x86_64}
+%endif
+
+%ifarch %{arm}
+images=%{images_arm}
+%endif
+
+%ifarch %{arm} aarch64
+images=%{images_arm64}
+%endif
+
+%ifarch ppc64le
+images=%{images_ppc64le}
+%endif
+
+%ifarch riscv64
+images=%{images_riscv64}
+%endif
+
+
+for val in ${images}; do
+    podman pull ${pull_arch} --root %{buildroot}%{imageStore} $val
+done
+
+# check, why do we need this?
+# sudo chmod -R a+rx  %{imageStore}
+
+%post
+
+# only on install (1), not on upgrades (2)
+if [ $1 -eq 1 ]; then
+   sed -i '/^additionalimagestores =*/a "%{imageStore}",' /etc/containers/storage.conf
+   # if crio was already started, restart it so it read from new imagestore
+   systemctl is-active --quiet crio && systemctl restart --quiet crio
+fi
+
+%postun
+
+# only on uninstall (0), not on upgrades(1)
+if [ $1 -eq 0 ];
+  sed -i '/"${imageStoreSed}",/d" /etc/containers/storage.conf
+  systemctl is-active --quiet crio && systemctl restart --quiet crio
+
+fi
+
+%files
+%{imageStore}/*
+
+%changelog
+* Wed Mar 2 2022 Miguel Angel Ajo <majopela@redhat.com> . 4.8.0_0.okd_2021_10_10_030117-2
+- Automatically get architecture images and OKD base version
+
+* Wed Feb 16 2022 Parul Singh <parsingh@redhat.com> . 4.8.0-0.microshiftr-2022_02_02_194009_3
+- Initial packaging of additional RO container storage.

--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -78,44 +78,6 @@ systems, scale testing, and provisioning of lightweight Kubernetes control plane
 Note: MicroShift is still early days and moving fast. Features are missing.
 Things break. But you can still help shape it, too.
 
-%package containerized
-Summary: Containerized systemd files for MicroShift
-BuildArch: noarch
-Requires: crio
-Requires: cri-tools
-Requires: microshift-selinux
-Requires: podman
-%{?selinux_requires}
-
-%description containerized
-This is the containerized version of MicroShift.
-
-MicroShift is a research project that is exploring how OpenShift Kubernetes
-can be optimized for small form factor and edge computing.
-
-Edge devices deployed out in the field pose very different operational,
-environmental, and business challenges from those of cloud computing.
-These motivate different engineering
-trade-offs for Kubernetes at the far edge than for cloud or near-edge
-scenarios. MicroShift's design goals cater to this:
-
-make frugal use of system resources (CPU, memory, network, storage, etc.),
-tolerate severe networking constraints, update (resp. roll back) securely,
-safely, speedily, and seamlessly (without disrupting workloads), and build on
-and integrate cleanly with edge-optimized OSes like Fedora IoT and RHEL for Edge,
-while providing a consistent development and management experience with standard
-OpenShift.
-
-We believe these properties should also make MicroShift a great tool for other
-use cases such as Kubernetes applications development on resource-constrained
-systems, scale testing, and provisioning of lightweight Kubernetes control planes.
-
-Note: MicroShift is still early days and moving fast. Features are missing.
-Things break. But you can still help shape it, too.
-
-%define microshift_relabel_files() \
-restorecon -R /var/hpvolumes
-
 %package selinux
 Summary: SELinux policies for MicroShift
 BuildRequires: selinux-policy
@@ -186,7 +148,6 @@ install -p -m644 packaging/crio.conf.d/microshift.conf %{buildroot}%{_sysconfdir
 
 install -d -m755 %{buildroot}/%{_unitdir}
 install -p -m644 packaging/systemd/microshift.service %{buildroot}%{_unitdir}/microshift.service
-install -p -m644 packaging/systemd/microshift-containerized.service %{buildroot}%{_unitdir}/microshift-containerized.service
 
 mkdir -p -m755 %{buildroot}/var/run/flannel
 mkdir -p -m755 %{buildroot}/var/run/kubelet
@@ -220,9 +181,6 @@ if [ $1 -eq 0 ]; then
     %selinux_modules_uninstall -s %{selinuxtype} microshift
 fi
 
-%post containerized
-mv /usr/lib/systemd/system/microshift-containerized.service /usr/lib/systemd/system/microshift.service
-
 %posttrans selinux
 
 %selinux_relabel_post -s %{selinuxtype}
@@ -250,11 +208,13 @@ mv /usr/lib/systemd/system/microshift-containerized.service /usr/lib/systemd/sys
 %{_datadir}/selinux/packages/%{selinuxtype}/microshift.pp.bz2
 %ghost %{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/microshift
 
-%files containerized
-
-%{_unitdir}/microshift-containerized.service
-
 %changelog
+* Wed Feb 2 2022 Miguel Angel Ajo <majopela@redhat.com> . 4.8.0-0.microshift-2022-01-06-210147-20
+- Remove the microshift-containerized subpackage, our docs explain how to download the .service file,
+  and it has proven problematic to package this.
+- Fix the microshift.service being overwritten by microshift-containerized, even when the non-containerized
+  package only is installed.
+
 * Thu Nov 4 2021 Miguel angel Ajo <majopela@redhat.com> . 4.8.0-nightly-14-g973b9c78
 - Add microshift-containerized subpackage which contains the microshift-containerized systemd
   definition.

--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -17,6 +17,17 @@
 %define selinux_policyver 3.14.3-67
 %define container_policyver 2.167.0-1
 %define container_policy_epoch 2
+%define microshift_relabel_files() \
+   mkdir -p /var/hpvolumes; \
+   mkdir -p /var/run/flannel; \
+   mkdir -p /var/run/kubelet; \
+   mkdir -p /var/lib/kubelet/pods; \
+   mkdir -p /var/run/secrets/kubernetes.io/serviceaccount; \
+   restorecon -R /var/hpvolumes; \
+   restorecon -R /var/run/kubelet; \
+   restorecon -R /var/run/flannel; \
+   restorecon -R /var/lib/kubelet/pods; \
+   restorecon -R /var/run/secrets/kubernetes.io/serviceaccount
 
 
 # Git related details
@@ -157,7 +168,6 @@ mkdir -p -m755 %{buildroot}/var/run/flannel
 mkdir -p -m755 %{buildroot}/var/run/kubelet
 mkdir -p -m755 %{buildroot}/var/lib/kubelet/pods
 mkdir -p -m755 %{buildroot}/var/run/secrets/kubernetes.io/serviceaccount
-mkdir -p -m755 %{buildroot}/var/hpvolumes
 
 install -d %{buildroot}%{_datadir}/selinux/packages/%{selinuxtype}
 install -m644 packaging/selinux/microshift.pp.bz2 %{buildroot}%{_datadir}/selinux/packages/%{selinuxtype}
@@ -177,7 +187,7 @@ fi
 %selinux_modules_install -s %{selinuxtype} %{_datadir}/selinux/packages/%{selinuxtype}/microshift.pp.bz2
 if /usr/sbin/selinuxenabled ; then
     %microshift_relabel_files
-fi;
+fi
 
 %postun selinux
 
@@ -208,11 +218,13 @@ fi
 /var/run/kubelet
 /var/lib/kubelet/pods
 /var/run/secrets/kubernetes.io/serviceaccount
-/var/hpvolumes
 %{_datadir}/selinux/packages/%{selinuxtype}/microshift.pp.bz2
 %ghost %{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/microshift
 
 %changelog
+* Mon Feb 7 2022 Ryan Cook <rcook@redhat.com> . 4.8.0-0.microshiftr-2022_02_02_194009_3
+- Selinux directory creation and labeling
+
 * Wed Feb 2 2022 Ryan Cook <rcook@redhat.com> . 4.8.0-0.microshift-2022_01_04_175420_25
 - Define specific selinux policy version to help manage selinux package
 

--- a/packaging/rpm/microshift.spec
+++ b/packaging/rpm/microshift.spec
@@ -14,6 +14,10 @@
 
 # SELinux specifics
 %global selinuxtype targeted
+%define selinux_policyver 3.14.3-67
+%define container_policyver 2.167.0-1
+%define container_policy_epoch 2
+
 
 # Git related details
 %global shortcommit %(c=%{git_commit}; echo ${c:0:7})
@@ -80,9 +84,9 @@ Things break. But you can still help shape it, too.
 
 %package selinux
 Summary: SELinux policies for MicroShift
-BuildRequires: selinux-policy
-BuildRequires: selinux-policy-devel
-Requires: container-selinux
+BuildRequires: selinux-policy >= %{selinux_policyver}
+BuildRequires: selinux-policy-devel >= %{selinux_policyver}
+Requires: container-selinux >= %{container_policy_epoch}:%{container_policyver}
 BuildArch: noarch
 %{?selinux_requires}
 
@@ -209,6 +213,9 @@ fi
 %ghost %{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/microshift
 
 %changelog
+* Wed Feb 2 2022 Ryan Cook <rcook@redhat.com> . 4.8.0-0.microshift-2022_01_04_175420_25
+- Define specific selinux policy version to help manage selinux package
+
 * Wed Feb 2 2022 Miguel Angel Ajo <majopela@redhat.com> . 4.8.0-0.microshift-2022-01-06-210147-20
 - Remove the microshift-containerized subpackage, our docs explain how to download the .service file,
   and it has proven problematic to package this.

--- a/packaging/systemd/microshift-containerized.service
+++ b/packaging/systemd/microshift-containerized.service
@@ -15,7 +15,7 @@ Restart=on-failure
 TimeoutStopSec=70
 ExecStartPre=/usr/bin/mkdir -p /var/lib/kubelet ; /usr/bin/mkdir -p /var/hpvolumes
 ExecStartPre=/bin/rm -f %t/%n.ctr-id
-ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --rm --replace --sdnotify=container --label io.containers.autoupdate=registry --network=host --privileged -d --name microshift -v /var/hpvolumes:/var/hpvolumes:z,rw,rshared -v /var/run/crio/crio.sock:/var/run/crio/crio.sock:rw,rshared -v microshift-data:/var/lib/microshift:rw,rshared -v /var/lib/kubelet:/var/lib/kubelet:z,rw,rshared -v /var/log:/var/log quay.io/microshift/microshift:latest
+ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon --rm --replace --sdnotify=container --label io.containers.autoupdate=registry --network=host --privileged -d --name microshift -v /var/hpvolumes:/var/hpvolumes:z,rw,rshared -v /var/run/crio/crio.sock:/var/run/crio/crio.sock:rw,rshared -v microshift-data:/var/lib/microshift:rw,rshared -v /var/lib/kubelet:/var/lib/kubelet:z,rw,rshared -v /var/log:/var/log -v /etc:/etc quay.io/microshift/microshift:latest
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 Type=notify

--- a/pkg/controllers/openshift-crd-manager.go
+++ b/pkg/controllers/openshift-crd-manager.go
@@ -39,10 +39,11 @@ func (s *OpenShiftCRDManager) Dependencies() []string {
 }
 
 func (s *OpenShiftCRDManager) Run(ctx context.Context, ready chan<- struct{}, stopped chan<- struct{}) error {
-	defer close(ready)
-	// To-DO add readiness check
+	defer close(stopped)
+
 	if err := assets.ApplyCRDs(s.cfg); err != nil {
 		klog.Errorf("%s unable to apply default CRDs: %v", s.Name(), err)
+		return err
 	}
 	klog.Infof("%s applied default CRDs", s.Name())
 
@@ -51,5 +52,7 @@ func (s *OpenShiftCRDManager) Run(ctx context.Context, ready chan<- struct{}, st
 		klog.Errorf("%s unable to confirm all CRDs are ready: %v", s.Name(), err)
 	}
 	klog.Infof("%s all CRDs are ready", s.Name())
+	close(ready)
+
 	return ctx.Err()
 }

--- a/pkg/release/get.sh
+++ b/pkg/release/get.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+function get_base {
+    grep "var Base" "${SCRIPT_DIR}/release.go"  | cut -d\" -f 2
+}
+
+function add_bases {
+    base=$(get_base)
+    sed "s/:$/:${base}/g" # some lines have "xxxxx:" + Base  like flannel
+}
+
+function get_image_list {
+
+    cat $1 | grep "Image = map\[string\]string" -A 100 | grep '":' | cut -d\" -f4 | \
+        add_bases
+}
+
+function get_images {
+    arch=$1
+    case $arch in
+        x86_64|amd64) get_image_list "${SCRIPT_DIR}/release_amd64.go" ;;
+        *) get_image_list "${SCRIPT_DIR}/release.go"              ;;
+    esac
+}
+
+function usage {
+    echo "usage:"
+    echo "   get.sh base                  : prints the OKD base version for this MicroShift codebase"
+    echo "   get.sh images <architecture> : prints image list used by this MicroShift codebase and architecture"
+    exit 1
+}
+
+case $1 in
+    base) get_base        ;;
+    images) get_images $2 ;;
+    *) usage
+esac
+
+

--- a/pkg/release/release_amd64.go
+++ b/pkg/release/release_amd64.go
@@ -28,7 +28,7 @@ func init() {
 		"kube_flannel_cni":              "quay.io/microshift/flannel-cni:" + Base,
 		"kube_rbac_proxy":               "quay.io/openshift/okd-content@sha256:459f15f0e457edaf04fa1a44be6858044d9af4de276620df46dc91a565ddb4ec",
 		"kubevirt_hostpath_provisioner": "quay.io/kubevirt/hostpath-provisioner:v0.8.0",
-		"pause":                         "k8s.gcr.io/pause",
+		"pause":                         "k8s.gcr.io/pause:3.2",
 		"service_ca_operator":           "quay.io/openshift/okd-content@sha256:dd1cd4d7b1f2d097eaa965bc5e2fe7ebfe333d6cbaeabc7879283af1a88dbf4e",
 	}
 }


### PR DESCRIPTION
- Remove the microshift-containerized subpackage (#595)
- force packaging versions (#594)
- OpenShift CRD Manager service must signal stop when completed (#581)
- Make kube-scheduler Service return errors for healthcheck (#584)
- Make kube-api-server to return errors from healthcheck (#585)
- Bot token (#597)
- Make kube-controller-manager service return errors (#583)
- Fix of selinux directories (#600)
- Install /etc/crio/crio.conf.d for containerized MicroShift (#608)
- Pre-loading container images into CRI-O (#568)
- Specify the right pause image used by cri-o (#611)
- WIP: pack containers into GitHub CI
